### PR TITLE
Fix Immediately Immobilized Caravans

### DIFF
--- a/v1.1/Source/Giddy-up-Caravan/Harmony/MassUtility_Capacity.cs
+++ b/v1.1/Source/Giddy-up-Caravan/Harmony/MassUtility_Capacity.cs
@@ -27,7 +27,20 @@ namespace GiddyUpCaravan.Harmony
             }
             else
             {
-                __result -= pawnData.caravanRider.GetStatValue(StatDefOf.Mass);
+                //new solution A - more forgiving
+                //float riderTotalMass = pawnData.caravanRider.GetStatValue(StatDefOf.Mass);
+                //float riderGearInvMass = MassUtility.GearAndInventoryMass(pawnData.caravanRider);
+                //float riderBodyMass = riderTotalMass - riderGearInvMass;
+                //__result -= riderBodyMass;
+                //__result = Math.Max(__result, 0f);
+
+                //new solution B - more restrictive
+                float riderTotalMass = pawnData.caravanRider.GetStatValue(StatDefOf.Mass);
+                float riderGearInvMass = MassUtility.GearAndInventoryMass(pawnData.caravanRider);
+                float riderBodyMass = riderTotalMass - riderGearInvMass;
+                float riderCapacity = MassUtility.Capacity(pawnData.caravanRider);
+                float riderGrossMass = riderBodyMass + riderCapacity;
+                __result -= riderGrossMass;
                 __result = Math.Max(__result, 0f);
             }
         }


### PR DESCRIPTION
I noticed that caravan capacity calculations were acting funny, so I explored this behavior with only Harmony, Core, HugsLib, GU-Core and GU-Caravans.  I wrote and play-tested two alternate versions of the code responsible for the weird behavior.  I've included both versions in this pull request - you will likely want to edit this after testing and deciding if you like it.

---
Problem: Some caravans become immediately immobilized upon embarking when animals are mounted, especially caravans near full mass capacity.

---
Observation: Let's form a caravan consisting of two naked colonists (2 x 35 kg capacity), a Muffalo (73.5 kg capacity), and three granite chunks (3 x 25 kg mass).  We assign one rider, which reduces the Muffalo's capacity by 60 kg.

The caravan's capacity will appear correctly in the caravan screen:
35 + 35 + ( 73.5 - 60 ) = 35 + 35 + 13.5 = 83.5 kg

The caravan cargo will also appear correctly:
3 x 25 = 75 kg

Therefore, the caravan formation screen shows that we are in good shape:
75 kg / 83.5 kg
(8.5 kg available capacity)

---
However:

Upon embarking, those three chunks are distributed to our two colonists and the Muffalo.  This is done either manually by colonists loading a caravan leaving the home settlement, or automatically by Dialog_FormCaravan.AddItemsFromTransferablesToRandomInventories when leaving from an encounter map.

Either way, each of the colonists now carries 25 of their 35 kg capacity.
35 - 25 = 10 kg available capacity

Vanilla MassUtility.Capacity then calculates the Muffalo's capacity:
73.5 - 25 = 48.5 kg available capacity

And then GiddyUp's MassUtility_Capacity patch subtracts the rider and his inventory:
__result -= pawnData.caravanRider.GetStatValue(StatDefOf.Mass);
48.5 - 85 = -36.5 kg

Then corrects the negative remaining capacity to 0:
__result = Math.Max(__result, 0f);
0 kg

Now our caravan capacity has been reduced to 
35 + 35 + 0 = 70 kg

And just like that, our caravan is immobilized, despite moments earlier boasting 8.5 kg excess capacity.
75 kg / 70 kg
(5 kg overextended capacity)

---
Notes:
The main problem right now is that due to the random cargo distribution, there is no way a player can predict how much mass a rider might be carrying (and therefore how much total mass capacity the caravan will have) until the caravan embarks, but by then it's too late to pack a reasonable load.  Further, there is no guarantee that the mass distribution will be equal.  In my tests, sometimes one colonist got two chunks and the other got none; other times, each colonist got one.

As in the example above, this often results in caravans that become immobilized immediately upon embarking - and the more colonists and animals in the group, the less reliable the caravan forming screen can be.

I believe the first step is to remove individual pawn inventories from the equation and simply focus on the overall mass carried and mass capacity.  This makes sense, because inventory mass will still be counted as mass carried, so it doesn't need to also reduce mass capacity.  Plus, we don't really care who is carrying which pieces of slag or chunks or blocks - we just care that the caravan can haul the prize home.

I'd like to propose two solutions that I've coded and tested in various situations.

Solution A - Easy Mode
Each mounted animal's mass capacity is reduced ONLY by rider body mass.
This solution would allow for some slightly inflated caravan capacities, because the rider's "backpack" would get a free ride on mounted animals.  Would encourage more riding.

Solution B - Hard Mode
Each mounted animal's mass capacity is reduced by (rider body mass + rider mass capacity).
This solution is more realistic and would make riding more costly - the animal will feel the weight of the rider AND his backpack.  If the rider has additional mass capacity, then the animal must account for that by reducing its own capacity.
This solution would widen the gap further between the rider speed bonus versus higher mass capacity.  Anecdotally, I played for a while with this option and strongly prefer it due to the greater importance placed on strategy.  With Solution A, it was almost always better for everyone to ride all the time.  With Solution B, there was great incentive to load up the animal with cargo and walk it home, and a higher cost when I had to abandon a significant amount of loot in order to mount up and hurry home because of the Flu.

Perhaps a mod option could offer a choice between Easy Mode and Hard Mode.

In either case, the mass capacity shown on the caravan formation screen becomes reliable and players can pack loot until their caravans are full to the brim, without risk of the caravan immediately becoming immobile upon embarking.

Thanks for the fantastic mods.  Hopefully players will enjoy this fix without causing too much extra work for you and the other contributors.